### PR TITLE
Handle change to json error format

### DIFF
--- a/src/client.php
+++ b/src/client.php
@@ -229,7 +229,8 @@ class client
         $rsp = json_decode($json, true);
 
         if (array_key_exists('error', $rsp)) {
-            throw new \InvalidArgumentException($rsp['error']);
+            $error = $rsp['error'];
+            throw new \InvalidArgumentException($error['info'], $error['code']);
         }
 
         return $rsp;


### PR DESCRIPTION
When CurrencyLayer sends an error response, they now send it like this:
```json
{
  "success": false,
  "error": {
    "code": 202,
    "info": "You have provided one or more invalid Currency Codes. (...)"
  }
}
```

This updates the exception thrown to properly include that error message and code.